### PR TITLE
feat!: state/function health for scheduled job

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,26 +97,32 @@ salt_new_job_total{function="state.sls",state="test",success="false"} 1
 salt_new_job_total{function="state.single",state="test.nop",success="true"} 3
 ```
 
-### Health Minions metrics
-By default, the state.highstate will also generate a health metrics:
-```
-salt_state_health{function="state.highstate",minion="node1",state="highstate"} 1
-```
-* `1` mean that the last time this couple of function/state were called, the return was `successful`
-* `0` mean that the last time this couple of function/state were called, the return was `failed`
+### Minions job status
 
-You will find a example of prometheus alerts that could be used with these default metrics in the prometheus_alerts directory.
+By default, a Salt highstate will generate a status metric:
+```
+salt_function_status{function="state.highstate",minion="node1",state="highstate"} 1
+```
+* `1` means that the last time this couple of function/state were executed, the return was `successful`
+* `0` means that the last time this couple of function/state were executed, the return was `failed`
 
-The health metrics can be customized by using the -health-functions-filter and -health-states-filter, example of usage:
+You will find an example of Prometheus alerts that could be used with this metric in the `prometheus_alerts` directory.
+
+The health metrics can be customized by using the `-health-functions-filter` and `-health-states-filter`, example of usage:
 ```
 ./salt-exporter -health-states-filter=test.ping,state.apply -health-functions-filter=""
 ```
-This will only generate health minion metrics for the test.ping function call:
+
+This will only generate a metric for the `test.ping` function executed:
 ```
-salt_state_health{function="test.ping",minion="node1",state=""} 1
+salt_function_status{function="test.ping",minion="node1",state=""} 1
 ```
+
 You can disable all the health metrics with this config switch:
 ```./salt-exporter -health-minions=false```
+
+Note: this also works for scheduled jobs.
+
 ### `salt/job/<jid>/new`
 
 It increases:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ salt_function_responses_total{function="state.highstate",state="highstate",succe
 salt_function_responses_total{function="state.sls",state="test",success="true"} 1
 salt_function_responses_total{function="state.single",state="test.nop",success="true"} 3
 
+salt_function_status{minion="node1",function="state.highstate",state="highstate"} 1
+
 salt_new_job_total{function="state.apply",state="highstate",success="false"} 1
 salt_new_job_total{function="state.highstate",state="highstate",success="false"} 2
 salt_new_job_total{function="state.sls",state="test",success="false"} 1
@@ -133,7 +135,7 @@ It increases:
 
 Usually, it will increase the `salt_responses_total` (per minion) and `salt_function_responses_total` (per function) counters.
 
-However, if it is a feedback of a scheduled job, it increases `salt_scheduled_job_return_total` instead.
+However, if it is of a scheduled job feedback, it increases `salt_scheduled_job_return_total` instead.
 
 #### Why separating `salt_responses_total` and `salt_scheduled_job_return_total`
 
@@ -154,7 +156,7 @@ It can be joined on function label to have details per executed module.
 
 ## Estimated performance
 
-According some simple benchmark, for a simple event, it takes:
+According to some simple benchmark, for a simple event, it takes:
 * ~60us for parsing
 * ~9us for converting to Prometheus metric
 
@@ -164,4 +166,4 @@ Roughly, the exporter should be able to handle about 10kQps.
 
 For a base of 1000 Salt minions, it should be able to sustain 10 jobs per minion per second, which is a quite high for Salt.
 
-If needed, the exporter can easily scale more up by doing the parsing in dedicated coroutines, the limiting factor being the Prometheus metric update (~9us).
+If needed, the exporter can easily scale more up by doing the parsing in dedicated goroutines, the limiting factor being the Prometheus metric update (~9us).

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -68,7 +68,7 @@ func ExposeMetrics(ctx context.Context, eventChan <-chan events.SaltEvent, metri
 
 	lastStateHealth := promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "salt_state_health",
+			Name: "salt_job_health",
 			Help: "Last state success state, 0=Failed, 1=Success",
 		},
 		[]string{"minion", "function", "state"},
@@ -112,15 +112,15 @@ func ExposeMetrics(ctx context.Context, eventChan <-chan events.SaltEvent, metri
 						state,
 						success,
 					).Inc()
+				}
 
-					if metricsConfig.HealthMinions {
-						if contains(metricsConfig.HealthFunctionsFilters, event.Data.Fun) &&
-							contains(metricsConfig.HealthStatesFilters, state) {
-							lastStateHealth.WithLabelValues(
-								event.Data.Id,
-								event.Data.Fun,
-								state).Set(boolToFloat64(event.Data.Success))
-						}
+				// Expose state/func status
+				if metricsConfig.HealthMinions {
+					if contains(metricsConfig.HealthFunctionsFilters, event.Data.Fun) && contains(metricsConfig.HealthStatesFilters, state) {
+						lastStateHealth.WithLabelValues(
+							event.Data.Id,
+							event.Data.Fun,
+							state).Set(boolToFloat64(event.Data.Success))
 					}
 				}
 			}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -50,10 +50,10 @@ func ExposeMetrics(ctx context.Context, eventChan <-chan events.SaltEvent, metri
 		},
 		[]string{"function", "state", "success"},
 	)
-	lastFunctionHealth := promauto.NewGaugeVec(
+	lastFunctionStatus := promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "salt_function_status",
-			Help: "Last state success function, 0=Failed, 1=Success",
+			Help: "Last function/state success, 0=Failed, 1=Success",
 		},
 		[]string{"minion", "function", "state"},
 	)
@@ -116,7 +116,7 @@ func ExposeMetrics(ctx context.Context, eventChan <-chan events.SaltEvent, metri
 				// Expose state/func status
 				if metricsConfig.HealthMinions {
 					if contains(metricsConfig.HealthFunctionsFilters, event.Data.Fun) && contains(metricsConfig.HealthStatesFilters, state) {
-						lastFunctionHealth.WithLabelValues(
+						lastFunctionStatus.WithLabelValues(
 							event.Data.Id,
 							event.Data.Fun,
 							state).Set(boolToFloat64(event.Data.Success))

--- a/prometheus_alerts/highstate.yaml
+++ b/prometheus_alerts/highstate.yaml
@@ -2,7 +2,7 @@ groups:
   - name: saltstack
     rules:
       - alert: SaltExporterLastHighstateSuccess
-        expr: sum by(minion) (salt_state_health{function="state.highstate", state="highstate"} == 0)
+        expr: sum by(minion) (salt_function_health{function="state.highstate", state="highstate"} == 0)
         for: 60m
         labels:
           severity: critical
@@ -11,7 +11,7 @@ groups:
           summary: "Salt Last Successful Highstate Failed (minion {{ $labels.minion }})"
           description: "Salt Last Successful Highstate failed since > 60m"
       - alert: SaltExporterLastHighstateSuccessInfo
-        expr: sum by(minion) (salt_state_health{function="state.highstate", state="highstate"} == 0)
+        expr: sum by(minion) (salt_function_health{function="state.highstate", state="highstate"} == 0)
         for: 10m
         labels:
           severity: info


### PR DESCRIPTION
PR #7 introduced a new metric to get the health of a function/state.

This PR extends the feature to scheduled jobs.

BREAKING CHANGE: `salt_state_health` is replaced by `salt_function_health`.