### PR TITLE
Configurable metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,32 +28,105 @@ Or, install via source:
 - latest release: `go install github.com/kpetremann/salt-exporter/cmd/salt-exporter@latest`
 - unstable: `go install github.com/kpetremann/salt-exporter/cmd/salt-exporter@main`
 
+## Deprecation notice
+
+`-health-minions`, `health-functions-filter` and `health-states-filter` are deprecated.
+They should be replaced by configuring metrics in the `config.yml` file.
+
+The equivalent of `./salt-exporter -health-minions -health-functions-filter "func1,func2" -health-states-filter "state1,state2"` is:
+
+```yaml
+metrics:
+  salt_responses_total:
+    enabled: true
+
+  salt_function_status:
+    enabled: true
+    filters:
+      functions:
+        - "func1"
+        - "func2"
+      states:
+        - "state1"
+        - "state2"
+```
+
 ## Usage
 
+Simply run:
+```./salt-exporter```
+
+The exporter can be configured using flags:
 ```
-./salt-exporter
+./salt-exporter -help
   -health-functions-filter string
-    	Apply filter on functions to monitor, separated by a comma (default "state.highstate")
-  -health-minions
-    	Enable minion metrics (default true)
+        [DEPRECATED] apply filter on functions to monitor, separated by a comma (default "highstate")
   -health-states-filter string
-    	Apply filter on states to monitor, separated by a comma (default "highstate")
+        [DEPRECATED] apply filter on states to monitor, separated by a comma (default "highstate")
+  -health-minions
+        [DEPRECATED] enable minion metrics (default true)
   -host string
-    	listen address
+        listen address
   -ignore-mock
-    	ignore mock=True events
+        ignore mock=True events
   -ignore-test
-    	ignore test=True events
+        ignore test=True events
   -log-level string
-    	log level (debug, info, warn, error, fatal, panic, disabled) (default "info")
+        log level (debug, info, warn, error, fatal, panic, disabled) (default "info")
   -port int
-    	listen port (default 2112)
+        listen port (default 2112)
   -tls
-    	enable TLS
+        enable TLS
   -tls-cert string
-    	TLS certificated
+        TLS certificated
   -tls-key string
-    	TLS private key
+        TLS private key
+```
+
+It can also be configured via a `config.yml` file, which provides more customization.
+
+The default settings are:
+```yaml
+listen-address: ""
+listen-port: 2112
+
+log-level: "info"
+tls:
+  enabled: true
+  key: "/path/to/key"
+  certificate: "/path/to/certificate"
+
+
+metrics:
+  global:
+    filters:
+      ignore-test: false
+      ignore-mock: false
+
+  salt_new_job_total:
+    enabled: true
+
+  salt_expected_responses_total:
+    enabled: true
+
+  salt_function_responses_total:
+    enabled: true
+    add-minion-label: false  # not recommended in production
+
+  salt_scheduled_job_return_total:
+    enabled: true
+    add-minion-label: false  # not recommended in production
+
+  salt_responses_total:
+    enabled: true
+
+  salt_function_status:
+    enabled: true
+    filters:
+      functions:
+        - "state.highstate"
+      states:
+        - "highstate"
 ```
 
 ## Features
@@ -68,6 +141,12 @@ It extracts and exposes:
 * the execution module, to `function` label
 * the states when using state.sls/state.apply/state.highstate, to `state` label
 * same info for the runners
+
+Each metrics can enabled or disabled via the configuration file.
+
+You can also add the minion label on some metrics. But be careful, this is not recommended on large environment as it could lead to cardinality issues!
+
+You can also filter out event run with `test=True` and/or `mock=True`.
 
 ## Exposed metrics
 

--- a/cmd/salt-exporter/config.go
+++ b/cmd/salt-exporter/config.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/k0kubun/pp/v3"
 	"github.com/kpetremann/salt-exporter/internal/metrics"
 	"github.com/spf13/viper"
 )
@@ -110,8 +111,10 @@ func getConfig() (Config, error) {
 	viper.AddConfigPath(".")
 
 	err := viper.ReadInConfig()
-	if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-		return Config{}, fmt.Errorf("invalid config file: %w", err)
+	if err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return Config{}, fmt.Errorf("invalid config file: %w", err)
+		}
 	}
 
 	// extract configuration
@@ -119,6 +122,8 @@ func getConfig() (Config, error) {
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return Config{}, fmt.Errorf("failed to load configuration: %w", err)
 	}
+
+	pp.Println(cfg)
 
 	return cfg, nil
 }

--- a/cmd/salt-exporter/config.go
+++ b/cmd/salt-exporter/config.go
@@ -55,14 +55,15 @@ func parseFlags() {
 	flag.Bool("ignore-test", false, "ignore test=True events")
 	flag.Bool("ignore-mock", false, "ignore mock=True events")
 
-	healthMinions := flag.Bool("health-minions", defaultHealthMinion, "enable minion metrics")
-	flag.String("health-functions-filter", defaultHealthStatesFilter,
+	// deprecated flag
+	healthMinions := flag.Bool("health-minions", defaultHealthMinion, "[DEPRECATED] enable minion metrics")
+	flag.String("[DEPRECATED] health-functions-filter", defaultHealthStatesFilter,
 		"apply filter on functions to monitor, separated by a comma")
-	flag.String("health-states-filter", defaultHealthStatesFilter,
+	flag.String("[DEPRECATED] health-states-filter", defaultHealthStatesFilter,
 		"apply filter on states to monitor, separated by a comma")
 	flag.Parse()
 
-	// ensure compatibility with health-minions flag
+	// ensure compatibility with deprecated health-minions flag
 	if !*healthMinions {
 		viper.SetDefault("metrics.salt_function_status.enabled", false)
 		viper.SetDefault("metrics.salt_responses_total.enabled", false)

--- a/cmd/salt-exporter/config.go
+++ b/cmd/salt-exporter/config.go
@@ -55,12 +55,18 @@ func parseFlags() {
 	flag.Bool("ignore-test", false, "ignore test=True events")
 	flag.Bool("ignore-mock", false, "ignore mock=True events")
 
-	flag.Bool("health-minions", defaultHealthMinion, "enable minion metrics")
+	healthMinions := flag.Bool("health-minions", defaultHealthMinion, "enable minion metrics")
 	flag.String("health-functions-filter", defaultHealthStatesFilter,
 		"apply filter on functions to monitor, separated by a comma")
 	flag.String("health-states-filter", defaultHealthStatesFilter,
 		"apply filter on states to monitor, separated by a comma")
 	flag.Parse()
+
+	// ensure compatibility with health-minions flag
+	if !*healthMinions {
+		viper.SetDefault("metrics.salt_function_status.enabled", false)
+		viper.SetDefault("metrics.salt_responses_total.enabled", false)
+	}
 }
 
 func setDefaults() {

--- a/cmd/salt-exporter/config.go
+++ b/cmd/salt-exporter/config.go
@@ -58,10 +58,10 @@ func parseFlags() {
 
 	// deprecated flag
 	healthMinions := flag.Bool("health-minions", defaultHealthMinion, "[DEPRECATED] enable minion metrics")
-	flag.String("[DEPRECATED] health-functions-filter", defaultHealthStatesFilter,
-		"apply filter on functions to monitor, separated by a comma")
-	flag.String("[DEPRECATED] health-states-filter", defaultHealthStatesFilter,
-		"apply filter on states to monitor, separated by a comma")
+	flag.String("health-functions-filter", defaultHealthStatesFilter,
+		"[DEPRECATED] apply filter on functions to monitor, separated by a comma")
+	flag.String("health-states-filter", defaultHealthStatesFilter,
+		"[DEPRECATED] apply filter on states to monitor, separated by a comma")
 	flag.Parse()
 
 	// ensure compatibility with deprecated health-minions flag

--- a/cmd/salt-exporter/config.go
+++ b/cmd/salt-exporter/config.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/kpetremann/salt-exporter/internal/metrics"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 const defaultLogLevel = "info"
@@ -74,8 +76,17 @@ func setDefaults() {
 	viper.SetDefault("log-level", defaultLogLevel)
 	viper.SetDefault("listen-port", defaultPort)
 	viper.SetDefault("metrics.health-minions", defaultHealthMinion)
+
+	viper.SetDefault("metrics.salt_new_job_total.enabled", true)
+	viper.SetDefault("metrics.salt_expected_responses_total.enabled", true)
+	viper.SetDefault("metrics.salt_function_responses_total.enabled", true)
+	viper.SetDefault("metrics.salt_scheduled_job_return_total.enabled", true)
+	viper.SetDefault("metrics.salt_responses_total.enabled", true)
+	viper.SetDefault("metrics.salt_function_status.enabled", true)
+
 	viper.SetDefault("metrics.salt_function_status.filters.functions", []string{defaultHealthFunctionsFilter})
 	viper.SetDefault("metrics.salt_function_status.filters.states", []string{defaultHealthStatesFilter})
+
 }
 
 func getConfig() (Config, error) {
@@ -110,6 +121,9 @@ func getConfig() (Config, error) {
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return Config{}, fmt.Errorf("failed to load configuration: %w", err)
 	}
+
+	out, _ := yaml.Marshal(cfg)
+	ioutil.WriteFile("config.yml", out, 0644)
 
 	return cfg, nil
 }

--- a/cmd/salt-exporter/config.go
+++ b/cmd/salt-exporter/config.go
@@ -4,11 +4,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/kpetremann/salt-exporter/internal/metrics"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 )
 
 const defaultLogLevel = "info"
@@ -121,9 +119,6 @@ func getConfig() (Config, error) {
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return Config{}, fmt.Errorf("failed to load configuration: %w", err)
 	}
-
-	out, _ := yaml.Marshal(cfg)
-	ioutil.WriteFile("config.yml", out, 0644)
 
 	return cfg, nil
 }

--- a/internal/metrics/config.go
+++ b/internal/metrics/config.go
@@ -11,7 +11,38 @@ type Config struct {
 		}
 	}
 
+	/*
+		New job metrics
+	*/
+
+	SaltNewJobTotal struct {
+		Enabled bool
+	} `mapstructure:"salt_new_job_total"`
+
+	SaltExpectedResponsesTotal struct {
+		Enabled bool
+	} `mapstructure:"salt_expected_responses_total"`
+
+	/*
+		Response metrics
+	*/
+
+	SaltFunctionResponsesTotal struct {
+		Enabled        bool
+		AddMinionLabel bool `mapstructure:"add-minion-label"`
+	} `mapstructure:"salt_function_responses_total"`
+
+	SaltScheduledJobReturnTotal struct {
+		Enabled        bool
+		AddMinionLabel bool `mapstructure:"salt_responses_total"`
+	} `mapstructure:"add-minion-label"`
+
+	SaltResponsesTotal struct {
+		Enabled bool
+	} `mapstructure:"salt_responses_total"`
+
 	SaltFunctionStatus struct {
+		Enabled bool
 		Filters struct {
 			Functions []string
 			States    []string

--- a/internal/metrics/config.go
+++ b/internal/metrics/config.go
@@ -34,8 +34,8 @@ type Config struct {
 
 	SaltScheduledJobReturnTotal struct {
 		Enabled        bool
-		AddMinionLabel bool `mapstructure:"salt_responses_total"`
-	} `mapstructure:"add-minion-label"`
+		AddMinionLabel bool `mapstructure:"add-minion-label"`
+	} `mapstructure:"salt_scheduled_job_return_total"`
 
 	SaltResponsesTotal struct {
 		Enabled bool

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -31,10 +31,10 @@ func eventToMetrics(event event.SaltEvent, r Registry) {
 			// - the substate success is false, and the global retcode is > 0
 			// using retcode could be enough, but in case there are other corner cases, we combine both values
 			success = event.Data.Success && (event.Data.Retcode == 0)
-			r.IncreaseScheduledJobReturnTotal(event.Data.Fun, state, success)
+			r.IncreaseScheduledJobReturnTotal(event.Data.Fun, state, event.Data.Id, success)
 		} else {
 			r.IncreaseResponseTotal(event.Data.Id, success) // TODO: move outside the if?
-			r.IncreaseFunctionResponsesTotal(event.Data.Fun, state, success)
+			r.IncreaseFunctionResponsesTotal(event.Data.Fun, state, event.Data.Id, success)
 		}
 
 		r.SetFunctionStatus(event.Data.Id, event.Data.Fun, state, success)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -2,12 +2,8 @@ package metrics
 
 import (
 	"context"
-	"strconv"
 
-	"github.com/kpetremann/salt-exporter/internal/filters"
 	"github.com/kpetremann/salt-exporter/pkg/event"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog/log"
 )
 
@@ -18,50 +14,35 @@ func boolToFloat64(b bool) float64 {
 	return 0.0
 }
 
-func ExposeMetrics(ctx context.Context, eventChan <-chan event.SaltEvent, metricsConfig Config) {
-	newJobCounter := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "salt_new_job_total",
-			Help: "Total number of new job processed",
-		},
-		[]string{"function", "state", "success"},
-	)
-	responsesCounter := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "salt_responses_total",
-			Help: "Total number of response job processed",
-		},
-		[]string{"minion", "success"},
-	)
-	functionResponsesCounter := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "salt_function_responses_total",
-			Help: "Total number of response per function processed",
-		},
-		[]string{"function", "state", "success"},
-	)
-	lastFunctionStatus := promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "salt_function_status",
-			Help: "Last function/state success, 0=Failed, 1=Success",
-		},
-		[]string{"minion", "function", "state"},
-	)
+func eventToMetrics(event event.SaltEvent, r Registry) {
+	switch event.Type {
+	case "new":
+		state := event.ExtractState()
+		r.IncreaseNewJobTotal(event.Data.Fun, state, true)
+		r.IncreaseExpectedResponsesTotal(event.Data.Fun, state, float64(event.TargetNumber))
 
-	scheduledJobReturnCounter := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "salt_scheduled_job_return_total",
-			Help: "Total number of scheduled job response",
-		},
-		[]string{"function", "state", "success"},
-	)
-	expectedResponsesNumber := promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "salt_expected_responses_total",
-			Help: "Total number of expected minions responses",
-		},
-		[]string{"function", "state"},
-	)
+	case "ret":
+		state := event.ExtractState()
+		success := event.Data.Success
+
+		if event.IsScheduleJob {
+			// for scheduled job, when the states in the job actually failed
+			// - the global "success" value is always true
+			// - the substate success is false, and the global retcode is > 0
+			// using retcode could be enough, but in case there are other corner cases, we combine both values
+			success = event.Data.Success && (event.Data.Retcode == 0)
+			r.IncreaseScheduledJobReturnTotal(event.Data.Fun, state, success)
+		} else {
+			r.IncreaseResponseTotal(event.Data.Id, success) // TODO: move outside the if?
+			r.IncreaseFunctionResponsesTotal(event.Data.Fun, state, success)
+		}
+
+		r.SetFunctionStatus(event.Data.Id, event.Data.Fun, state, success)
+	}
+}
+
+func ExposeMetrics(ctx context.Context, eventChan <-chan event.SaltEvent, config Config) {
+	registry := NewRegistry(config)
 
 	for {
 		select {
@@ -69,59 +50,14 @@ func ExposeMetrics(ctx context.Context, eventChan <-chan event.SaltEvent, metric
 			log.Info().Msg("stopping event listener")
 			return
 		case event := <-eventChan:
-			if metricsConfig.Global.Filters.IgnoreTest && event.IsTest || metricsConfig.Global.Filters.IgnoreMock && event.IsMock {
+			if config.Global.Filters.IgnoreTest && event.IsTest {
+				return
+			}
+			if config.Global.Filters.IgnoreMock && event.IsMock {
 				return
 			}
 
-			switch event.Type {
-			case "new":
-				state := event.ExtractState()
-				newJobCounter.WithLabelValues(event.Data.Fun, state, "true").Inc()
-				expectedResponsesNumber.WithLabelValues(event.Data.Fun, state).Add(float64(event.TargetNumber))
-			case "ret":
-				var success bool
-				state := event.ExtractState()
-				if event.IsScheduleJob {
-					// for scheduled job, when the states in the job actually failed
-					// - the global "success" value is always true
-					// - the substate success is false, and the global retcode is > 0
-					// using retcode could be enough, but in case there are other corner cases, we combine both values
-					success = event.Data.Success && (event.Data.Retcode == 0)
-					scheduledJobReturnCounter.WithLabelValues(
-						event.Data.Fun,
-						state,
-						strconv.FormatBool(success),
-					).Inc()
-				} else {
-					success = event.Data.Success
-
-					if metricsConfig.HealthMinions {
-						responsesCounter.WithLabelValues(
-							event.Data.Id,
-							strconv.FormatBool(success),
-						).Inc()
-					}
-
-					functionResponsesCounter.WithLabelValues(
-						event.Data.Fun,
-						state,
-						strconv.FormatBool(success),
-					).Inc()
-				}
-
-				// Expose state/func status if feature enabled and matching filters
-				if !metricsConfig.HealthMinions {
-					continue
-				}
-				if !filters.Match(event.Data.Fun, metricsConfig.SaltFunctionStatus.Filters.Functions) {
-					continue
-				}
-				log.Debug().Msg("function matches")
-				if !filters.Match(state, metricsConfig.SaltFunctionStatus.Filters.States) {
-					continue
-				}
-				lastFunctionStatus.WithLabelValues(event.Data.Id, event.Data.Fun, state).Set(boolToFloat64(success))
-			}
+			eventToMetrics(event, registry)
 		}
 	}
 }

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -1,0 +1,120 @@
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/kpetremann/salt-exporter/internal/filters"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Registry struct {
+	config Config
+
+	newJobTotal            *prometheus.CounterVec
+	expectedResponsesTotal *prometheus.CounterVec
+
+	functionResponsesTotal  *prometheus.CounterVec
+	scheduledJobReturnTotal *prometheus.CounterVec
+
+	responseTotal  *prometheus.CounterVec
+	functionStatus *prometheus.GaugeVec
+}
+
+func NewRegistry(config Config) Registry {
+	return Registry{
+		config: config,
+
+		newJobTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "salt_new_job_total",
+				Help: "Total number of new job processed",
+			},
+			[]string{"function", "state", "success"},
+		),
+
+		expectedResponsesTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "salt_expected_responses_total",
+				Help: "Total number of expected minions responses",
+			},
+			[]string{"function", "state"},
+		),
+
+		functionResponsesTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "salt_function_responses_total",
+				Help: "Total number of response per function processed",
+			},
+			[]string{"function", "state", "success"},
+		),
+
+		scheduledJobReturnTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "salt_scheduled_job_return_total",
+				Help: "Total number of scheduled job response",
+			},
+			[]string{"function", "state", "success"},
+		),
+
+		responseTotal: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "salt_responses_total",
+				Help: "Total number of response job processed",
+			},
+			[]string{"minion", "success"},
+		),
+
+		functionStatus: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "salt_function_status",
+				Help: "Last function/state success, 0=Failed, 1=Success",
+			},
+			[]string{"minion", "function", "state"},
+		),
+	}
+}
+
+func (r Registry) IncreaseNewJobTotal(function, state string, success bool) {
+	if r.config.SaltNewJobTotal.Enabled {
+		r.newJobTotal.WithLabelValues(function, state, strconv.FormatBool(success)).Inc()
+	}
+}
+
+func (r Registry) IncreaseExpectedResponsesTotal(function, state string, value float64) {
+	if r.config.SaltExpectedResponsesTotal.Enabled {
+		r.expectedResponsesTotal.WithLabelValues(function, state).Add(value)
+	}
+}
+
+func (r Registry) IncreaseFunctionResponsesTotal(function, state string, success bool) {
+	if r.config.SaltFunctionResponsesTotal.Enabled {
+		r.functionResponsesTotal.WithLabelValues(function, state, strconv.FormatBool(success)).Inc()
+	}
+}
+
+func (r Registry) IncreaseScheduledJobReturnTotal(function, state string, success bool) {
+	if r.config.SaltScheduledJobReturnTotal.Enabled {
+		r.scheduledJobReturnTotal.WithLabelValues(function, state, strconv.FormatBool(success)).Inc()
+	}
+}
+
+func (r Registry) IncreaseResponseTotal(minion string, success bool) {
+	if r.config.SaltResponsesTotal.Enabled {
+		r.responseTotal.WithLabelValues(minion, strconv.FormatBool(success)).Inc()
+	}
+}
+
+func (r Registry) SetFunctionStatus(minion, function, state string, success bool) {
+	if !r.config.SaltFunctionStatus.Enabled {
+		return
+	}
+	if !filters.Match(function, r.config.SaltFunctionStatus.Filters.Functions) {
+		return
+	}
+	if !filters.Match(state, r.config.SaltFunctionStatus.Filters.States) {
+		return
+	}
+
+	r.functionStatus.WithLabelValues(minion, function, state).Set(boolToFloat64(success))
+}


### PR DESCRIPTION
each metrics can now be enabled/disabled.

Some can be filtered or customized.

Example of configuration:
```yaml
metrics:
  global:
    filters:
      ignore-test: false
      ignore-mock: false

  salt_new_job_total:
    enabled: true

  salt_expected_responses_total:
    enabled: true

  salt_function_responses_total:
    enabled: true
    add-minion-label: false  # not recommended in production

  salt_scheduled_job_return_total:
    enabled: true
    add-minion-label: false  # not recommended in production

  salt_responses_total:
    enabled: true

  salt_function_status:
    enabled: true
    filters:
      functions:
        - "state.highstate"
      states:
        - "highstate"
```

Note: It deprecated `-health-minions`, `health-functions-filter` and `health-states-filter` flags. They should be replaced by configuring metrics in the `config.yml` file.