### PR TITLE
Schedule advanced success check

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -30,14 +30,15 @@ type EventData struct {
 }
 
 type SaltEvent struct {
-	Tag           string
-	Type          string
-	TargetNumber  int
-	Data          EventData
-	IsScheduleJob bool
-	RawBody       []byte
-	IsTest        bool
-	IsMock        bool
+	Tag                string
+	Type               string
+	TargetNumber       int
+	Data               EventData
+	IsScheduleJob      bool
+	RawBody            []byte
+	IsTest             bool
+	IsMock             bool
+	StateModuleSuccess *bool
 }
 
 // RawToJSON converts raw body to JSON

--- a/pkg/parser/fake_state_data_test.go
+++ b/pkg/parser/fake_state_data_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 var False = false
+var True = true
 
 /*
 	Fake state.sls job
@@ -134,9 +135,10 @@ var expectedStateSlsReturn = event.SaltEvent{
 		},
 		Success: true,
 	},
-	IsScheduleJob: false,
-	IsTest:        false,
-	IsMock:        false,
+	IsScheduleJob:      false,
+	IsTest:             false,
+	IsMock:             false,
+	StateModuleSuccess: &True,
 }
 
 func fakeStateSlsReturnEvent() []byte {
@@ -329,9 +331,10 @@ var expectedStateSingleReturn = event.SaltEvent{
 		},
 		Success: true,
 	},
-	IsScheduleJob: false,
-	IsTest:        false,
-	IsMock:        false,
+	IsScheduleJob:      false,
+	IsTest:             false,
+	IsMock:             false,
+	StateModuleSuccess: &True,
 }
 
 func fakeStateSingleReturnEvent() []byte {

--- a/pkg/parser/fake_state_data_test.go
+++ b/pkg/parser/fake_state_data_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
+var False = false
+
 /*
 	Fake state.sls job
 
@@ -474,7 +476,7 @@ func fakeNewTestMockStateSlsJobEvent() []byte {
 		"id": "node1",
 		"jid": "20220630000000000000",
 		"out": "highstate",
-		"retcode": 0,
+		"retcode": 1,
 		"return": {
 			"somestate_|-dummy somestate_|-Dummy somestate_|-nop": {
 				"__id__": "dummy somestate",
@@ -486,7 +488,23 @@ func fakeNewTestMockStateSlsJobEvent() []byte {
 				"name": "Dummy somestate",
 				"result": true,
 				"start_time": "09:17:08.822722"
-			}
+			},
+			"somestate_|-failed_|-failed_|-fail_with_changes": {
+				"__id__": "failed",
+				"__run_num__": 2,
+				"__sls__": "test",
+				"changes": {
+					"testing": {
+						"new": "Something pretended to change",
+						"old": "Unchanged"
+					}
+				},
+				"comment": "Failure!",
+				"duration": 0.579,
+				"name": "failed",
+				"result": false,
+				"start_time": "09:17:02.812345"
+			},
 		},
 		"success": true
 	}
@@ -511,7 +529,7 @@ var expectedTestMockStateSlsReturn = event.SaltEvent{
 		Id:      "node1",
 		Jid:     "20220630000000000000",
 		Out:     "highstate",
-		Retcode: 0,
+		Retcode: 1,
 		Return: map[string]interface{}{
 			"somestate_|-dummy somestate_|-Dummy somestate_|-nop": map[string]interface{}{
 				"__id__":      "dummy somestate",
@@ -524,12 +542,24 @@ var expectedTestMockStateSlsReturn = event.SaltEvent{
 				"result":      true,
 				"start_time":  "09:17:08.822722",
 			},
+			"somestate_|-failed_|-failed_|-fail_with_changes": map[string]interface{}{
+				"__id__":      "dummy somestate",
+				"__run_num__": int8(2),
+				"__sls__":     "somestate",
+				"changes":     map[string]interface{}{},
+				"comment":     "Failure!",
+				"duration":    0.579,
+				"name":        "failed",
+				"result":      false,
+				"start_time":  "09:17:08.812345",
+			},
 		},
 		Success: true,
 	},
-	IsScheduleJob: false,
-	IsTest:        true,
-	IsMock:        true,
+	IsScheduleJob:      false,
+	IsTest:             true,
+	IsMock:             true,
+	StateModuleSuccess: &False,
 }
 
 func fakeTestMockStateSlsReturnEvent() []byte {
@@ -548,7 +578,7 @@ func fakeTestMockStateSlsReturnEvent() []byte {
 		Id:      "node1",
 		Out:     "highstate",
 		Jid:     "20220630000000000000",
-		Retcode: 0,
+		Retcode: 1,
 		Return: map[string]interface{}{
 			"somestate_|-dummy somestate_|-Dummy somestate_|-nop": map[string]interface{}{
 				"__id__":      "dummy somestate",
@@ -560,6 +590,17 @@ func fakeTestMockStateSlsReturnEvent() []byte {
 				"name":        "Dummy somestate",
 				"result":      true,
 				"start_time":  "09:17:08.822722",
+			},
+			"somestate_|-failed_|-failed_|-fail_with_changes": map[string]interface{}{
+				"__id__":      "dummy somestate",
+				"__run_num__": int8(2),
+				"__sls__":     "somestate",
+				"changes":     map[string]interface{}{},
+				"comment":     "Failure!",
+				"duration":    0.579,
+				"name":        "failed",
+				"result":      false,
+				"start_time":  "09:17:08.812345",
 			},
 		},
 		Success: true,

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -62,7 +62,7 @@ func getBoolKwarg(event event.SaltEvent, field string) bool {
 	return false
 }
 
-func substateResult(event event.SaltEvent) *bool {
+func statemoduleResult(event event.SaltEvent) *bool {
 	substates, ok := event.Data.Return.(map[string]interface{})
 	if !ok {
 		return nil
@@ -125,7 +125,7 @@ func (e Event) Parse(message map[string]interface{}) (event.SaltEvent, error) {
 	ev.IsScheduleJob = ev.Data.Schedule != ""
 	ev.IsTest = getBoolKwarg(ev, testArg)
 	ev.IsMock = getBoolKwarg(ev, mockArg)
-	ev.StateModuleSuccess = substateResult(ev)
+	ev.StateModuleSuccess = statemoduleResult(ev)
 
 	// A runner are executed on the master but they do not provide their ID in the event
 	if strings.HasPrefix(tag, "salt/run") && ev.Data.Id == "" {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -62,6 +62,37 @@ func getBoolKwarg(event event.SaltEvent, field string) bool {
 	return false
 }
 
+func substateResult(event event.SaltEvent) *bool {
+	substates, ok := event.Data.Return.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, ret := range substates {
+		substate, ok := ret.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		result, ok := substate["result"]
+		if !ok {
+			return nil
+		}
+
+		r, ok := result.(bool)
+		if !ok {
+			return nil
+		}
+
+		if !r {
+			return &r
+		}
+	}
+
+	success := true
+	return &success
+}
+
 // ParseEvent parses a salt event
 func (e Event) Parse(message map[string]interface{}) (event.SaltEvent, error) {
 	body := string(message["body"].([]byte))
@@ -94,6 +125,7 @@ func (e Event) Parse(message map[string]interface{}) (event.SaltEvent, error) {
 	ev.IsScheduleJob = ev.Data.Schedule != ""
 	ev.IsTest = getBoolKwarg(ev, testArg)
 	ev.IsMock = getBoolKwarg(ev, mockArg)
+	ev.StateModuleSuccess = substateResult(ev)
 
 	// A runner are executed on the master but they do not provide their ID in the event
 	if strings.HasPrefix(tag, "salt/run") && ev.Data.Id == "" {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -14,56 +14,56 @@ func TestParseEvent(t *testing.T) {
 		args map[string]interface{}
 		want event.SaltEvent
 	}{
-		// {
-		// 	name: "new job",
-		// 	args: fakeEventAsMap(fakeNewJobEvent()),
-		// 	want: expectedNewJob,
-		// },
-		// {
-		// 	name: "return job",
-		// 	args: fakeEventAsMap(fakeRetJobEvent()),
-		// 	want: expectedReturnJob,
-		// },
-		// {
-		// 	name: "new schedule job",
-		// 	args: fakeEventAsMap(fakeNewScheduleJobEvent()),
-		// 	want: expectedNewScheduleJob,
-		// },
-		// {
-		// 	name: "return ack schedule job",
-		// 	args: fakeEventAsMap(fakeAckScheduleJobEvent()),
-		// 	want: expectedAckScheduleJob,
-		// },
-		// {
-		// 	name: "return schedule job",
-		// 	args: fakeEventAsMap(fakeScheduleJobReturnEvent()),
-		// 	want: expectedScheduleJobReturn,
-		// },
-		// {
-		// 	name: "new state.sls",
-		// 	args: fakeEventAsMap(fakeNewStateSlsJobEvent()),
-		// 	want: expectedNewStateSlsJob,
-		// },
-		// {
-		// 	name: "return state.sls",
-		// 	args: fakeEventAsMap(fakeStateSlsReturnEvent()),
-		// 	want: expectedStateSlsReturn,
-		// },
-		// {
-		// 	name: "new state.single",
-		// 	args: fakeEventAsMap(fakeNewStateSingleEvent()),
-		// 	want: expectedNewStateSingle,
-		// },
-		// {
-		// 	name: "return state.single",
-		// 	args: fakeEventAsMap(fakeStateSingleReturnEvent()),
-		// 	want: expectedStateSingleReturn,
-		// },
-		// {
-		// 	name: "new state.sls test=True mock=True",
-		// 	args: fakeEventAsMap(fakeNewTestMockStateSlsJobEvent()),
-		// 	want: expectedNewTestMockStateSlsJob,
-		// },
+		{
+			name: "new job",
+			args: fakeEventAsMap(fakeNewJobEvent()),
+			want: expectedNewJob,
+		},
+		{
+			name: "return job",
+			args: fakeEventAsMap(fakeRetJobEvent()),
+			want: expectedReturnJob,
+		},
+		{
+			name: "new schedule job",
+			args: fakeEventAsMap(fakeNewScheduleJobEvent()),
+			want: expectedNewScheduleJob,
+		},
+		{
+			name: "return ack schedule job",
+			args: fakeEventAsMap(fakeAckScheduleJobEvent()),
+			want: expectedAckScheduleJob,
+		},
+		{
+			name: "return schedule job",
+			args: fakeEventAsMap(fakeScheduleJobReturnEvent()),
+			want: expectedScheduleJobReturn,
+		},
+		{
+			name: "new state.sls",
+			args: fakeEventAsMap(fakeNewStateSlsJobEvent()),
+			want: expectedNewStateSlsJob,
+		},
+		{
+			name: "return state.sls",
+			args: fakeEventAsMap(fakeStateSlsReturnEvent()),
+			want: expectedStateSlsReturn,
+		},
+		{
+			name: "new state.single",
+			args: fakeEventAsMap(fakeNewStateSingleEvent()),
+			want: expectedNewStateSingle,
+		},
+		{
+			name: "return state.single",
+			args: fakeEventAsMap(fakeStateSingleReturnEvent()),
+			want: expectedStateSingleReturn,
+		},
+		{
+			name: "new state.sls test=True mock=True",
+			args: fakeEventAsMap(fakeNewTestMockStateSlsJobEvent()),
+			want: expectedNewTestMockStateSlsJob,
+		},
 		{
 			name: "return state.sls test=True mock=True",
 			args: fakeEventAsMap(fakeTestMockStateSlsReturnEvent()),

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -14,56 +14,56 @@ func TestParseEvent(t *testing.T) {
 		args map[string]interface{}
 		want event.SaltEvent
 	}{
-		{
-			name: "new job",
-			args: fakeEventAsMap(fakeNewJobEvent()),
-			want: expectedNewJob,
-		},
-		{
-			name: "return job",
-			args: fakeEventAsMap(fakeRetJobEvent()),
-			want: expectedReturnJob,
-		},
-		{
-			name: "new schedule job",
-			args: fakeEventAsMap(fakeNewScheduleJobEvent()),
-			want: expectedNewScheduleJob,
-		},
-		{
-			name: "return ack schedule job",
-			args: fakeEventAsMap(fakeAckScheduleJobEvent()),
-			want: expectedAckScheduleJob,
-		},
-		{
-			name: "return schedule job",
-			args: fakeEventAsMap(fakeScheduleJobReturnEvent()),
-			want: expectedScheduleJobReturn,
-		},
-		{
-			name: "new state.sls",
-			args: fakeEventAsMap(fakeNewStateSlsJobEvent()),
-			want: expectedNewStateSlsJob,
-		},
-		{
-			name: "return state.sls",
-			args: fakeEventAsMap(fakeStateSlsReturnEvent()),
-			want: expectedStateSlsReturn,
-		},
-		{
-			name: "new state.single",
-			args: fakeEventAsMap(fakeNewStateSingleEvent()),
-			want: expectedNewStateSingle,
-		},
-		{
-			name: "return state.single",
-			args: fakeEventAsMap(fakeStateSingleReturnEvent()),
-			want: expectedStateSingleReturn,
-		},
-		{
-			name: "new state.sls test=True mock=True",
-			args: fakeEventAsMap(fakeNewTestMockStateSlsJobEvent()),
-			want: expectedNewTestMockStateSlsJob,
-		},
+		// {
+		// 	name: "new job",
+		// 	args: fakeEventAsMap(fakeNewJobEvent()),
+		// 	want: expectedNewJob,
+		// },
+		// {
+		// 	name: "return job",
+		// 	args: fakeEventAsMap(fakeRetJobEvent()),
+		// 	want: expectedReturnJob,
+		// },
+		// {
+		// 	name: "new schedule job",
+		// 	args: fakeEventAsMap(fakeNewScheduleJobEvent()),
+		// 	want: expectedNewScheduleJob,
+		// },
+		// {
+		// 	name: "return ack schedule job",
+		// 	args: fakeEventAsMap(fakeAckScheduleJobEvent()),
+		// 	want: expectedAckScheduleJob,
+		// },
+		// {
+		// 	name: "return schedule job",
+		// 	args: fakeEventAsMap(fakeScheduleJobReturnEvent()),
+		// 	want: expectedScheduleJobReturn,
+		// },
+		// {
+		// 	name: "new state.sls",
+		// 	args: fakeEventAsMap(fakeNewStateSlsJobEvent()),
+		// 	want: expectedNewStateSlsJob,
+		// },
+		// {
+		// 	name: "return state.sls",
+		// 	args: fakeEventAsMap(fakeStateSlsReturnEvent()),
+		// 	want: expectedStateSlsReturn,
+		// },
+		// {
+		// 	name: "new state.single",
+		// 	args: fakeEventAsMap(fakeNewStateSingleEvent()),
+		// 	want: expectedNewStateSingle,
+		// },
+		// {
+		// 	name: "return state.single",
+		// 	args: fakeEventAsMap(fakeStateSingleReturnEvent()),
+		// 	want: expectedStateSingleReturn,
+		// },
+		// {
+		// 	name: "new state.sls test=True mock=True",
+		// 	args: fakeEventAsMap(fakeNewTestMockStateSlsJobEvent()),
+		// 	want: expectedNewTestMockStateSlsJob,
+		// },
 		{
 			name: "return state.sls test=True mock=True",
 			args: fakeEventAsMap(fakeTestMockStateSlsReturnEvent()),


### PR DESCRIPTION
Due to a Salt inconsistency, a failing scheduled job can report to be successful.

For a Scheduled Job, sometimes a failing jobs can have either:
- retcode=0
- success=True
- no retcode defined in each function of the state

The most precise way to know the real status is to parse the "result" field in Event.Return, meaning get the "result" boolean provided in each function of the state.

For example, if we have the given state:
```
  dummy test:
    test.nop:
      - name: "nop"

  success:
    test.succeed_with_changes:
      - name: "success"

  failed:
    test.fail_with_changes:
      - name: "failed"
```

We get the "result", which is a boolean, for the dummy test, success and failed. If one of them returns "false", we consider the state failed.