### PR TITLE
Updating docs with minions health configuration and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ salt_responses_total{minion="local",success="true"} 6
 salt_responses_total{minion="node1",success="true"} 6
 
 salt_scheduled_job_return_total{function="state.sls",minion="local",state="test",success="true"} 2
+
+salt_health_last_heartbeat{minion="local"} 1703053536
+salt_health_last_heartbeat{minion="node1"} 1703053536
+
+salt_health_minions_total{} 2
 ```
 
 ### Deprecation notice

--- a/cmd/salt-exporter/config_test.go
+++ b/cmd/salt-exporter/config_test.go
@@ -120,7 +120,7 @@ func TestReadConfigFlagOnly(t *testing.T) {
 				ListenAddress: "127.0.0.1",
 				ListenPort:    8080,
 				IPCFile:       "/dev/null",
-				PKIDir:        "/etc/salt/pki",
+				PKIDir:        "/etc/salt/pki/master",
 				TLS: struct {
 					Enabled     bool
 					Key         string

--- a/docs/docs/salt-exporter/configuration.md
+++ b/docs/docs/salt-exporter/configuration.md
@@ -26,6 +26,9 @@ log-level: "info"
 listen-address: ""
 listen-port: 2112
 
+pki-dir: /etc/salt/pki/master
+ipc-file: /var/run/salt/master/master_event_pub.ipc
+
 tls:
   enabled: true
   key: "/path/to/key"
@@ -70,6 +73,7 @@ metrics:
 | log-level      | `info`    | log level can be: debug, info, warn, error, fatal, panic, disabled |
 | listen-address | `0.0.0.0` | listening address                                                  |
 | listen-port    | `2112`    | listening port                                                     |
+| pki-dir        | `/etc/salt/pki/master` | path to Salt master's PKI directory   |
 
 ### TLS settings
 
@@ -100,6 +104,19 @@ All parameters below are in the `metrics` section of the configuration.
 | `<metrics_name>`.add-minion-label<br /><br />Only for:<br /><ul><li>`salt_function_responses_total`</li><li>`salt_scheduled_job_return_total`</li></ul> | `false` | adds minion label<br />_not recommended<br />can lead to cardinality issues_ |
 | salt_function_status.filters.function | `state.highstate` | updates the metric only if the event function matches the filter |
 | salt_function_status.filters.states | `highstate` | updates the metric only if the event state matches the filter |
+
+### Minions health detection
+
+In most of the cases all that you need to configure is to enable [`status` beacon](https://docs.saltproject.io/en/latest/ref/beacons/all/salt.beacons.status.html#:~:text=salt.-,beacons.,presence%20to%20be%20set%20up.) on Salt minions.
+However, if you change the [pki directory](https://docs.saltproject.io/en/latest/ref/configuration/master.html#pki-dir) for Salt master, you'll need to make a change in the exporter side too by changing it in the configuration
+```yaml
+log-level: "info"
+
+pki-dir: /path/as/set/in/master/config
+
+tls:
+...
+```
 
 ## Alternative methods
 

--- a/pkg/listener/pkiwatcher.go
+++ b/pkg/listener/pkiwatcher.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const DefaultPKIDirpath = "/etc/salt/pki"
+const DefaultPKIDirpath = "/etc/salt/pki/master"
 
 type PKIWatcher struct {
 	ctx context.Context
@@ -62,7 +62,7 @@ func (w *PKIWatcher) open() {
 		default:
 		}
 
-		minionsDir := path.Join(w.pkiDirPath, "master/minions")
+		minionsDir := path.Join(w.pkiDirPath, "minions")
 
 		log.Info().Msg("loading currently accepted minions")
 		entries, err := os.ReadDir(minionsDir)


### PR DESCRIPTION
Updating the docs with information how to use minion's health functionality and what is providing.

Also, changing default PKI directory to exactly match the one from Salt's configuration.