### PR TITLE
fix: ignore .key_cache and .___atomic_write* files on minions pki dir

### DIFF
--- a/pkg/listener/pkiwatcher.go
+++ b/pkg/listener/pkiwatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -96,6 +97,9 @@ func (w *PKIWatcher) StartWatching() {
 			return
 		case evt := <-w.watcher.Events:
 			minionName := path.Base(evt.Name)
+			if minionName == ".key_cache" || strings.HasPrefix(minionName, ".___atomic_write") {
+				continue
+			}
 			if evt.Op == fsnotify.Create {
 				w.eventChan <- event.WatchEvent{
 					MinionName: minionName,


### PR DESCRIPTION
When `key_cache: sched` is set on the salt master, it will periodically update the `.key_cache` file under `/etc/salt/pki/master/minions/`. Also, the result of the update of the key_cache is a `.___atomic_write*` file created on the same directory (then when the file is closed it's renamed .key_cache cf https://github.com/saltstack/salt/blob/master/salt/master.py#L339 / https://github.com/saltstack/salt/blob/master/salt/utils/atomicfile.py#L161).

This will cause salt-exporter to falsely report those files as minions keys accepted by master i.e:

logs:
```
 7:11AM INF minion .___atomic_write9mh8n9ns accepted by master
 7:11AM INF minion .key_cache accepted by master
 7:12AM INF minion .___atomic_writem4smkxpt accepted by master
 7:12AM INF minion .key_cache accepted by master
```

metrics:
```
salt_health_last_heartbeat{minion=".___atomic_writez5_23euj"} 1.717311428e+09
salt_health_last_heartbeat{minion=".___atomic_writez5_4cs8w"} 1.717859222e+09
salt_health_last_heartbeat{minion=".___atomic_writez5_bu6l7"} 1.716473273e+09
salt_health_last_heartbeat{minion=".___atomic_writez5cmyjxk"} 1.718778782e+09
salt_health_last_heartbeat{minion=".___atomic_writez5d139t4"} 1.717697485e+09
salt_health_last_heartbeat{minion=".___atomic_writez5dufvh8"} 1.719816411e+09
salt_health_last_heartbeat{minion=".___atomic_writez5f3_3ji"} 1.71680666e+09
salt_health_last_heartbeat{minion=".___atomic_writez5fyr928"} 1.716654744e+09
salt_health_last_heartbeat{minion=".___atomic_writez5gaps20"} 1.717285954e+09
salt_health_last_heartbeat{minion=".___atomic_writez5i4a96r"} 1.719200304e+09
salt_health_last_heartbeat{minion=".___atomic_writez5iqa8yq"} 1.71846716e+09
salt_health_last_heartbeat{minion=".___atomic_writez5kau_rz"} 1.719257208e+09
salt_health_last_heartbeat{minion=".___atomic_writez5ml9t1t"} 1.717942271e+09
salt_health_last_heartbeat{minion=".___atomic_writez5mqep72"} 1.716631256e+09
salt_health_last_heartbeat{minion=".___atomic_writez5n3r51u"} 1.71686079e+09
salt_health_last_heartbeat{minion=".___atomic_writez5o4i7iy"} 1.718700818e+09
salt_health_last_heartbeat{minion=".___atomic_writez5oaslhs"} 1.718468918e+09
salt_health_last_heartbeat{minion=".___atomic_writez5oypc1z"} 1.717830021e+09
salt_health_last_heartbeat{minion=".___atomic_writez5rd2438"} 1.717703938e+09
salt_health_last_heartbeat{minion=".___atomic_writez5rqznm1"} 1.718669715e+09
salt_health_last_heartbeat{minion=".___atomic_writez5x7r3rt"} 1.71900015e+09
```

This MR ignore those files.