### PR TITLE
Fix tls

### DIFF
--- a/cmd/salt-exporter/config.go
+++ b/cmd/salt-exporter/config.go
@@ -41,9 +41,9 @@ type Config struct {
 	IPCFile       string `mapstructure:"ipc-file"`
 	PKIDir        string `mapstructure:"pki-dir"`
 	TLS           struct {
-		Enabled     bool
-		Key         string
-		Certificate string
+		Enabled     bool   `mapstructure:"enabled"`
+		Key         string `mapstructure:"key"`
+		Certificate string `mapstructure:"certificate"`
 	}
 
 	Metrics metrics.Config

--- a/cmd/salt-exporter/config_test.go
+++ b/cmd/salt-exporter/config_test.go
@@ -30,9 +30,9 @@ func TestReadConfigFlagOnly(t *testing.T) {
 				IPCFile:       listener.DefaultIPCFilepath,
 				PKIDir:        listener.DefaultPKIDirpath,
 				TLS: struct {
-					Enabled     bool
-					Key         string
-					Certificate string
+					Enabled     bool   `mapstructure:"enabled"`
+					Key         string `mapstructure:"key"`
+					Certificate string `mapstructure:"certificate"`
 				}{
 					Enabled:     false,
 					Key:         "",
@@ -129,9 +129,9 @@ func TestReadConfigFlagOnly(t *testing.T) {
 				IPCFile:       "/dev/null",
 				PKIDir:        "/etc/salt/pki/master",
 				TLS: struct {
-					Enabled     bool
-					Key         string
-					Certificate string
+					Enabled     bool   `mapstructure:"enabled"`
+					Key         string `mapstructure:"key"`
+					Certificate string `mapstructure:"certificate"`
 				}{
 					Enabled:     true,
 					Key:         "./key",
@@ -263,9 +263,9 @@ func TestConfigFileOnly(t *testing.T) {
 		IPCFile:       "/dev/null",
 		PKIDir:        "/tmp/pki",
 		TLS: struct {
-			Enabled     bool
-			Key         string
-			Certificate string
+			Enabled     bool   `mapstructure:"enabled"`
+			Key         string `mapstructure:"key"`
+			Certificate string `mapstructure:"certificate"`
 		}{
 			Enabled:     true,
 			Key:         "/path/to/key",
@@ -382,9 +382,9 @@ func TestConfigFileWithFlags(t *testing.T) {
 		IPCFile:       "/somewhere",
 		PKIDir:        "/tmp/pki",
 		TLS: struct {
-			Enabled     bool
-			Key         string
-			Certificate string
+			Enabled     bool   `mapstructure:"enabled"`
+			Key         string `mapstructure:"key"`
+			Certificate string `mapstructure:"certificate"`
 		}{
 			Enabled:     true,
 			Key:         "/path/to/key",


### PR DESCRIPTION
(Retry of #83)

The TLS struct fields in the Config were missing mapstructure tags, preventing Viper from properly unmarshaling the TLS configuration from config files, environment variables, or command-line flags. This caused all TLS settings to remain empty/disabled, resulting in the server always serving HTTP instead of HTTPS.

Changes:

Added mapstructure tags to TLS struct fields (enabled, key, certificate) in cmd/salt-exporter/config.go
This allows the TLS configuration to be properly loaded and enables the server to correctly serve over HTTPS when TLS is configured.

Fixes the issue where TLS configuration was being ignored and the server defaulted to HTTP.

This resolves #84 